### PR TITLE
Footer Settings Changed

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001591",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001591.tgz",
-      "integrity": "sha512-PCzRMei/vXjJyL5mJtzNiUCKP59dm8Apqc3PH8gJkMnMXZGox93RbE76jHsmLwmIo6/3nsYIpJtx0O7u5PqFuQ==",
+      "version": "1.0.30001696",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001696.tgz",
+      "integrity": "sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==",
       "dev": true,
       "funding": [
         {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,7 +49,7 @@ function App() {
         <Route path='/register' element={<Register />} />
       </Routes>
       </AuthProvider>
-      <Footer/>
+      {/* <Footer/> */}
     </div>
   );
 }


### PR DESCRIPTION
### **User description**
Add the footer Settings


___

### **PR Type**
Enhancement, Other


___

### **Description**
- Updated the `caniuse-lite` dependency version in `package-lock.json`.

- Commented out the `Footer` component in `App.jsx`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package-lock.json</strong><dd><code>Update `caniuse-lite` dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/package-lock.json

<li>Updated the <code>caniuse-lite</code> dependency version.<br> <li> Adjusted integrity hash for the updated version.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S59_situational_comebacks/pull/23/files#diff-925cb809ce77c7f7f7f8bbd7594593438fc006dc56bf432a624c47722a784d3d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.jsx</strong><dd><code>Comment out `Footer` component in `App.jsx`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/src/App.jsx

- Commented out the `Footer` component in the main application file.


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S59_situational_comebacks/pull/23/files#diff-51b002bf85fbd146b38871b89ba0d41c2bead37756295748c67206aac23ddc9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>